### PR TITLE
Cci quickfix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,7 +85,7 @@ workflows:
   stable:
     jobs:
       - refresh_cache
-      - build_stable
+      - build_stable:
           requires:
             - refresh_cache
       - do_deploy:
@@ -97,6 +97,6 @@ workflows:
   nightly:
     jobs:
       - refresh_cache
-      - build_nightly
+      - build_nightly:
           requires:
             - refresh_cache

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,6 +86,8 @@ workflows:
     jobs:
       - refresh_cache
       - build_stable
+          requires:
+            - refresh_cache
       - do_deploy:
           requires:
             - build_stable
@@ -96,3 +98,5 @@ workflows:
     jobs:
       - refresh_cache
       - build_nightly
+          requires:
+            - refresh_cache


### PR DESCRIPTION
This adds a quick fix so that the build will run _only_ after the cache is refreshed and saved.